### PR TITLE
Registers controller actions with Sails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "9"
 
 sudo: false
 

--- a/lib/marlinspike.js
+++ b/lib/marlinspike.js
@@ -1,106 +1,129 @@
-import requireAll from 'require-all'
-import path from 'path'
-import _ from 'lodash'
+import requireAll from 'require-all';
+import path from 'path';
+import _ from 'lodash';
 
 export default class Marlinspike {
 
   constructor (sails, hookModule) {
-    this.sails = sails
-    this.name = this.constructor.name.toLowerCase()
-    this.hookPath = path.resolve(path.dirname(hookModule.filename))
+    this.sails = sails;
+    this.name = this.constructor.name.toLowerCase();
+    this.hookPath = path.resolve(path.dirname(hookModule.filename));
 
-    this.sails.log.debug('hookPath:', this.hookPath)
+    this.sails.log.debug('hookPath:', this.hookPath);
   }
 
   configure () {
-    return { }
+    return { };
   }
   initialize (next) {
-    next()
+    next();
   }
   routes () {
-    return { }
+    return { };
   }
   defaults (overrides) {
-    return { }
+    return { };
   }
 
   loadConfig () {
-    let configPath = path.resolve(this.hookPath, '../../../config')
-    this.sails.log.debug(`marlinspike (${this.name}): loading config from ${configPath}`)
+    let configPath = path.resolve(this.hookPath, '../../../config');
+    this.sails.log.debug(`marlinspike (${this.name}): loading config from ${configPath}`);
     try {
       let configModules = requireAll({
         dirname: configPath,
         filter: /(.+)\.js$/
-      })
-      let sailsConfig = _.reduce(_.values(configModules), _.merge)
-      _.defaultsDeep(this.sails.config, sailsConfig)
+      });
+      let sailsConfig = _.reduce(_.values(configModules), _.merge);
+      _.defaultsDeep(this.sails.config, sailsConfig);
     }
     catch (e) {
-      this.sails.log.debug(`marlinspike (${this.name}): no configuration found in ${configPath}. Skipping...`)
+      this.sails.log.debug(`marlinspike (${this.name}): no configuration found in ${configPath}. Skipping...`);
     }
   }
-  
+
   loadModels () {
-    this.sails.log.debug(`marlinspike (${this.name}): loading Models...`)
+    this.sails.log.debug(`marlinspike (${this.name}): loading Models...`);
     try {
       let models = requireAll({
         dirname: path.resolve(this.hookPath, '../../models'),
         filter: /(.+)\.js$/
-      })
-      this.mergeEntities('models', models)
+      });
+      this.mergeEntities('models', models);
     }
     catch (e) {
-      this.sails.log.warn(`marlinspike (${this.name}): no Models found. skipping`)
+      this.sails.log.warn(`marlinspike (${this.name}): no Models found. skipping`);
     }
   }
 
   loadPolicies () {
-    this.sails.log.debug(`marlinspike (${this.name}): loading Policies...`)
+    this.sails.log.debug(`marlinspike (${this.name}): loading Policies...`);
     try {
       let policies = requireAll({
         dirname: path.resolve(this.hookPath, '../../policies'),
         filter: /(.+)\.js$/
-      })
+      });
       _.extend(this.sails.hooks.policies.middleware, _.mapKeys(policies, (policy, key) => {
-        return key.toLowerCase()
-      }))
+        return key.toLowerCase();
+      }));
     }
     catch (e) {
-      this.sails.log.warn(`marlinspike (${this.name}): no Policies found. skipping`)
+      this.sails.log.warn(`marlinspike (${this.name}): no Policies found. skipping`);
     }
 
   }
 
-  loadControllers () {
-    this.sails.log.debug(`marlinspike (${this.name}): loading Controllers...`)
+  registerActions () {
+    this.sails.log.debug(`marlinspike (${this.name}): loading Controllers...`);
     try {
       let controllers = requireAll({
         dirname: path.resolve(this.hookPath, '../../controllers'),
         filter: /(.+Controller)\.js$/,
         map (name, path) {
-          return name.replace(/Controller/, '')
+          return name.replace(/Controller/, '');
         }
-      })
-      this.mergeEntities('controllers', controllers)
+      });
+      _.forOwn(controllers, (action, controllerName) => {
+        _.forOwn(action, (func, actionName) => {
+          if (typeof func === 'function') {
+            this.sails.registerAction(func, `${controllerName}/${actionName}`.toLowerCase(), true);
+          }
+        });
+      });
     }
     catch (e) {
-      this.sails.log.warn(`marlinspike (${this.name}): no Controllers found. skipping`)
+      this.sails.log.warn(`marlinspike (${this.name}): no Actions found. skipping`);
+    }
+  }
+
+  loadControllers () {
+    this.sails.log.debug(`marlinspike (${this.name}): loading Controllers...`);
+    try {
+      let controllers = requireAll({
+        dirname: path.resolve(this.hookPath, '../../controllers'),
+        filter: /(.+Controller)\.js$/,
+        map (name, path) {
+          return name.replace(/Controller/, '');
+        }
+      });
+      this.mergeEntities('controllers', controllers);
+    }
+    catch (e) {
+      this.sails.log.warn(`marlinspike (${this.name}): no Controllers found. skipping`);
     }
   }
 
   loadServices () {
-    let servicesPath = path.resolve(this.hookPath, '../../services')
-    this.sails.log.debug(`marlinspike (${this.name}): loading Services from ${servicesPath}...`)
+    let servicesPath = path.resolve(this.hookPath, '../../services');
+    this.sails.log.debug(`marlinspike (${this.name}): loading Services from ${servicesPath}...`);
     try {
       let services = requireAll({
         dirname: servicesPath,
         filter: /(.+)\.js$/
-      })
-      this.mergeEntities('services', services)
+      });
+      this.mergeEntities('services', services);
     }
     catch (e) {
-      this.sails.log.warn(`marlinspike (${this.name}): no Services found. skipping`)
+      this.sails.log.warn(`marlinspike (${this.name}): no Services found. skipping`);
     }
   }
 
@@ -108,7 +131,7 @@ export default class Marlinspike {
    * load modules into the sails namespace
    */
   mergeEntities (ns, entities) {
-    this.sails[ns] = _.merge(this.sails[ns] || { }, Marlinspike.transformEntities(entities))
+    this.sails[ns] = _.merge(this.sails[ns] || { }, Marlinspike.transformEntities(entities));
   }
 
   static transformEntities (entities) {
@@ -117,12 +140,12 @@ export default class Marlinspike {
         return _.defaults(entity, {
           globalId: key,
           identity: key.toLowerCase()
-        })
+        });
       })
       .mapKeys((entity, key) => {
         return key.toLowerCase();
       })
-      .value()
+      .value();
   }
 
   static defaultConfig () {
@@ -133,7 +156,7 @@ export default class Marlinspike {
         services: true,
         policies: true
       }
-    }
+    };
   }
 
   /**
@@ -144,37 +167,53 @@ export default class Marlinspike {
    */
   static createSailsHook (Hook) {
     return sails => {
-      const hook = new Hook(sails)
-      hook.loadConfig(Hook.constructor.name)
+      const hook = new Hook(sails);
+      hook.loadConfig(Hook.constructor.name);
 
-      let config = _.defaults({ }, Marlinspike.defaultConfig())
-      if (hook.name in sails.config) _.extend(config.marlinspike, sails.config[hook.name].marlinspike)
+      let config = _.defaults({ }, Marlinspike.defaultConfig());
+      if (hook.name in sails.config) {
+        _.extend(config.marlinspike, sails.config[hook.name].marlinspike);
+      }
 
       return {
         name: this.name,
         routes: hook.routes(),
         defaults (overrides) {
-          return _.merge(config, hook.defaults(overrides))
+          return _.merge(config, hook.defaults(overrides));
         },
         configure () {
-          if (config.marlinspike.services) hook.loadServices()
-          if (config.marlinspike.models) hook.loadModels()
-          if (config.marlinspike.controllers) hook.loadControllers()
-          if (config.marlinspike.policies) hook.loadPolicies()
+          if (config.marlinspike.services) {
+            hook.loadServices();
+          }
+          if (config.marlinspike.models) {
+            hook.loadModels();
+          }
+          if (config.marlinspike.controllers) {
+            hook.loadControllers();
+          }
+          if (config.marlinspike.policies) {
+            hook.loadPolicies();
+          }
 
-          hook.configure()
-          sails.emit(`hook:${hook.name}:configured`)
+          hook.configure();
+          sails.emit(`hook:${hook.name}:configured`);
         },
         initialize (next) {
 
           hook.initialize(() => {
-            sails.emit(`hook:${hook.name}:initialized`)
-            next()
-          })
+            // Check for `registerAction` for backwards compatibility
+            if (config.marlinspike.controllers &&
+                typeof sails.registerAction === 'function') {
+              hook.registerActions();
+            }
+
+            sails.emit(`hook:${hook.name}:initialized`);
+            next();
+          });
         }
-      }
-    }
+      };
+    };
   }
 }
 
-export default Marlinspike
+export default Marlinspike;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "babel": "^5.8.21",
     "gulp-babel": "^5.2.0",
     "mocha": "^2.2.5",
-    "sails": "balderdashy/sails"
+    "sails": "balderdashy/sails",
+    "sails-hook-orm": "^1.0.9"
   },
   "bundledDependencies": [
     "lodash",


### PR DESCRIPTION
Sails 1.0.0 requires controller actions to be registered explicitly. This contribution adds support for such a case, including a check for `sails.registerAction` for backwards compatibility.

For completion, this contribution also adds semicolon to all lines.